### PR TITLE
make type optional

### DIFF
--- a/lib/literal/data.rb
+++ b/lib/literal/data.rb
@@ -2,7 +2,7 @@
 
 class Literal::Data < Literal::DataStructure
 	class << self
-		def prop(name, type, kind = :keyword, reader: :public, predicate: false, default: nil)
+		def prop(name, type = nil, kind = :keyword, reader: :public, predicate: false, default: nil)
 			super(name, type, kind, reader:, writer: false, predicate:, default:)
 		end
 

--- a/lib/literal/enum.rb
+++ b/lib/literal/enum.rb
@@ -10,7 +10,7 @@ class Literal::Enum
 
 		def values = @values.keys
 
-		def prop(name, type, kind = :keyword, reader: :public, default: nil)
+		def prop(name, type = nil, kind = :keyword, reader: :public, default: nil)
 			super(name, type, kind, reader:, writer: false, default:)
 		end
 

--- a/lib/literal/properties.rb
+++ b/lib/literal/properties.rb
@@ -6,7 +6,7 @@ module Literal::Properties
 
 	include Literal::Types
 
-	def prop(name, type, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, &coercion)
+	def prop(name, type = nil, kind = :keyword, reader: false, writer: false, predicate: false, default: nil, &coercion)
 		if default && !(Proc === default || default.frozen?)
 			raise Literal::ArgumentError.new("The default must be a frozen object or a Proc.")
 		end

--- a/lib/literal/struct.rb
+++ b/lib/literal/struct.rb
@@ -2,7 +2,7 @@
 
 class Literal::Struct < Literal::DataStructure
 	class << self
-		def prop(name, type, kind = :keyword, reader: :public, writer: :public, default: nil)
+		def prop(name, type = nil, kind = :keyword, reader: :public, writer: :public, default: nil)
 			super
 		end
 	end


### PR DESCRIPTION
Make type optional

### Caveat
To specify `kind` add the extra `nil` to cover the `type` argument:
```ruby
  prop :label, nil, :positional
  prop :args, nil, :**
```